### PR TITLE
Update CrossTalker_install_basicusage.rmd - duplicate vignette index

### DIFF
--- a/vignettes/CrossTalker_install_basicusage.rmd
+++ b/vignettes/CrossTalker_install_basicusage.rmd
@@ -44,7 +44,7 @@ author:
 output:
      html_document
 vignette: |
-      %\VignetteIndexEntry{CrossTalkeR-HumanMyfib}
+      %\VignetteIndexEntry{CrossTalker_install_basicusage}
       %\VignetteEngine{knitr::rmarkdown}
       %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
This fixes a duplicated vignette index name that was preventing installation in R 4.2.1.